### PR TITLE
Showing links in editing mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Obsidian Smart Links
 
-This is a plugin for [Obsidian](https://obsidian.md) that lets you define custom "smart" links which will be auto-linked when reading documents.
+This is a plugin for [Obsidian](https://obsidian.md) that lets you define custom "smart" links which will be auto-linked when editing or reading documents.
 
 If you're used to writing in an environment that auto-links certain strings and don't want to build new habits, this will help with that. E.g. `T12345` in phabricator, or `#4324` in github.
 
@@ -33,3 +33,5 @@ The replacements work using normal Javascript regular expression replacement syn
 ## Credits
 
 The reading-mode code was heavily influenced by [Obsidian GoLinks](https://github.com/xavdid/obsidian-golinks) -- this plugin is (arguably) a customizable superset of that one's functionality.
+
+The editing-mode code was made possible by [the documentation on the unofficial Obsidian Plugin Developer Docs site](https://marcus.se.net/obsidian-plugin-docs/) which is maintained by volunteer contributors.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a plugin for [Obsidian](https://obsidian.md) that lets you define custom "smart" links which will be auto-linked when editing or reading documents.
 
-If you're used to writing in an environment that auto-links certain strings and don't want to build new habits, this will help with that. E.g. `T12345` in phabricator, or `#4324` in github.
+If you're used to writing in an environment that auto-links certain strings and don't want to build new habits, this will help with that. E.g. `T12345` in Phabricator, `#4324` in GitHub, or `REF-123` in Jira.
 
 It'll turn this...
 
@@ -22,11 +22,12 @@ You can add your own replacement patterns in Obsidian's settings:
 
 Install and enable the plugin. Once you do, you'll find there's a new section in your settings called "Smart Links". In it you can add/remove replacement rules. You'll need to write a regular expression and a replacement string for it. This can range from very simple to very complicated.
 
-| Regular expression | Replacement                             |
-|--------------------|-----------------------------------------|
-| `T\d+`             | `https://phabricator.wikimedia.org/$&`  |
-| `\$([A-Z]+)`       | `https://finance.yahoo.com/quote/$1`    |
-| `go\/[_\d\w-/]+`   | `http://$&`                             |
+| Regular expression | Replacement                              |
+|--------------------|------------------------------------------|
+| `T\d+`             | `https://phabricator.wikimedia.org/$&`   |
+| `\$([A-Z]+)`       | `https://finance.yahoo.com/quote/$1`     |
+| `REF-(\d+)`        | `https://my.atlassian.net/browse/REF-$1` |
+| `go\/[_\d\w-/]+`   | `http://$&`                              |
 
 The replacements work using normal Javascript regular expression replacement syntax. I'm so very sorry. Remember that you'll need to escape characters with special meaning in regular expressions. Matches are restricted so they'll only occur immediately after either the start of a line or some whitespace.
 

--- a/main.ts
+++ b/main.ts
@@ -1,6 +1,10 @@
 import { App, Editor, MarkdownRenderChild, MarkdownView, Modal, Notice, Plugin, PluginSettingTab, Setting } from 'obsidian';
 
-import { SmartLinksPattern, parseNextLink } from 'replacements';
+import { SmartLinksPattern, parseNextLink, createLinkTag, LinkPlugin } from 'replacements';
+
+import {
+	ViewPlugin,
+} from "@codemirror/view";
 
 interface SmartLinksSettings {
 	patterns: [{regexp: string, replacement: string}];
@@ -41,6 +45,15 @@ export default class SmartLinks extends Plugin {
 				}
 			})
 		})
+
+		this.registerEditorExtension(
+			ViewPlugin.define<LinkPlugin>(
+				(view) => new LinkPlugin(view, this),
+				{
+					decorations: (value: LinkPlugin) => value.decorations,
+				}
+			),
+		)
 	}
 
 	onunload() {
@@ -197,25 +210,11 @@ class SmartLinkContainer extends MarkdownRenderChild {
 					break;
 				}
 				results.push(document.createTextNode(nextLink.preText));
-				results.push(this.createLinkTag(containerEl, nextLink.link, nextLink.href));
+				results.push(createLinkTag(containerEl, nextLink.link, nextLink.href));
 				remaining = nextLink.remaining;
 			}
 		});
 
 		return results;
-	}
-
-	createLinkTag(el: Element, link: string, href: string): Element {
-		return el.createEl("a", {
-			cls: "external-link",
-			href,
-			text: link,
-			attr: {
-				"aria-label": href,
-				"aria-label-position": "top",
-				rel: "noopener",
-				target: "_blank",
-			}
-		})
 	}
 }

--- a/replacements.ts
+++ b/replacements.ts
@@ -95,7 +95,7 @@ export class LinkPlugin implements PluginValue {
 	buildDecorations(view: EditorView): DecorationSet {
 		const builder = new RangeSetBuilder<Decoration>();
 
-		if ( ! this.plugin || ! this.plugin.patterns) {
+		if ( ! this.plugin?.patterns) {
 			return builder.finish();
 		}
 
@@ -118,20 +118,12 @@ export class LinkPlugin implements PluginValue {
 						break;
 					}
 
-					const match = pattern.match(remaining);
-
-					if (! match || ! match.index) {
-						break;
-					}
-
-					listCharFrom += match.index + match[0].length;
-
-					const href = match[0].replace(pattern.regexp, pattern.replacement);
+					listCharFrom += nextLink.index + nextLink.link.length;
 
 					additions.push({
 						position: listCharFrom,
 						decoration: Decoration.widget({
-							widget: new LinkWidget(match[0], href),
+							widget: new LinkWidget(nextLink.link, nextLink.href),
 						})
 					});
 
@@ -145,11 +137,7 @@ export class LinkPlugin implements PluginValue {
 
 		// Add decorations in sorted order
 		for (const { position, decoration } of additions) {
-			builder.add(
-				position,
-				position,
-				decoration
-			);
+			builder.add(position, position, decoration);
 		}
 
 		return builder.finish();
@@ -157,14 +145,8 @@ export class LinkPlugin implements PluginValue {
 }
 
 export class LinkWidget extends WidgetType {
-	text: string;
-	link: string;
-
-	constructor(text:string, link:string) {
+	constructor(private text:string, private link:string) {
 		super();
-
-		this.text = text;
-		this.link = link;
 	}
 
 	toDOM(view: EditorView): HTMLElement {

--- a/replacements.ts
+++ b/replacements.ts
@@ -76,12 +76,10 @@ export function createLinkTag(el: Element, link: string, href: string): HTMLElem
 }
 
 export class LinkPlugin implements PluginValue {
-	plugin: SmartLinks;
 	decorations: DecorationSet;
 
-	constructor(view: EditorView, plugin: SmartLinks) {
+	constructor(view: EditorView, private plugin: SmartLinks) {
 		this.decorations = this.buildDecorations(view);
-		this.plugin = plugin;
 	}
 
 	update(update: ViewUpdate) {
@@ -95,7 +93,7 @@ export class LinkPlugin implements PluginValue {
 	buildDecorations(view: EditorView): DecorationSet {
 		const builder = new RangeSetBuilder<Decoration>();
 
-		if ( ! this.plugin?.patterns) {
+		if (! this.plugin?.patterns) {
 			return builder.finish();
 		}
 

--- a/replacements.ts
+++ b/replacements.ts
@@ -63,7 +63,7 @@ export function parseNextLink(text: string, pattern: SmartLinksPattern):
 
 export function createLinkTag(el: Element, link: string, href: string): HTMLElement {
 	return el.createEl("a", {
-		cls: "external-link",
+		cls: "external-link smart-link",
 		href,
 		text: link,
 		attr: {

--- a/replacements.ts
+++ b/replacements.ts
@@ -98,6 +98,11 @@ export class LinkPlugin implements PluginValue {
 			return builder.finish();
 		}
 
+		const additions: {
+			position: number;
+			decoration: Decoration;
+		}[] = [];
+
 		for (const { from, to } of view.visibleRanges) {
 			const text = view.state.sliceDoc(from, to);
 
@@ -111,14 +116,25 @@ export class LinkPlugin implements PluginValue {
 				const listCharFrom = from + match.index + match[0].length;
 				const href = match[0].replace(pattern.regexp, pattern.replacement);
 
-				builder.add(
-					listCharFrom,
-					listCharFrom,
-					Decoration.widget({
+				additions.push({
+					position: listCharFrom,
+					decoration: Decoration.widget({
 						widget: new LinkWidget(match[0], href),
 					})
-				);
+				});
 			}
+		}
+
+		// Sort additions by position
+		additions.sort((a, b) => a.position - b.position);
+
+		// Add decorations in sorted order
+		for (const { position, decoration } of additions) {
+			builder.add(
+				position,
+				position,
+				decoration
+			);
 		}
 
 		return builder.finish();

--- a/styles.css
+++ b/styles.css
@@ -14,3 +14,6 @@ If your plugin does not need CSS, delete this file.
     color: red;
     border-color: red;
 }
+.markdown-source-view:not(.is-live-preview) .smart-link {
+    display: none;
+}


### PR DESCRIPTION
Fixes #1.

Shows the smart links while in editing mode.

Work in progress, but it's functional.

## Todo

* [ ] Better positioning/formatting for the link
* [x] Don't operate when in Source mode
* [x] Allow for more than one instance of each matching link
* [x] Order returned decorations by `from` position ascending (triggers a JavaScript error when they're returned out of order)
* [ ] Unit tests
* [x] Documentation

## Screenshot

<img width="299" alt="" src="https://user-images.githubusercontent.com/208434/230214038-25c8758f-125a-446b-b049-496664dd8214.png">
